### PR TITLE
Adiciona guia de contribuição

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Requisitos para contribuir
+
+- Preencha o modelo abaixo. Qualquer *Pull Request* que não inclua informação suficiente para ser revisado em tempo hábil poderá ser fechado por decisão dos mantenedores.
+
+### Descrição da mudança
+
+<!--
+
+Nós devemos conseguir entender o motivo da mudança através dessa descrição. Se não conseguirmos entender muito bem os benefícios que esta mudança trará, o *Pull Request* pode ser fechado.
+
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Como contribuir para o Meetup Cookbook do PUG-PE?
+
+Primeiramente, muito obrigado por estar pensando em contribuir! :smile::smile:
+
+Neste documento é apresentado um conjunto de diretrizes para contribuição a este projeto. Essas diretrizes não são exatamente regras, mas seguí-las ajuda todo mundo a estar na mesma página. Se quiser submeter um *pull request* para este documento, sinta-se à vontade. No geral, use o bom senso.
+
+## Código de Conduta
+
+Este projeto e todos participando nele estão sujeitos ao [código de conduta](https://python.org.br/cdc/). Ao participar, é esperado que você também o siga.
+
+## Como posso contribuir?
+
+### Sugerindo melhorias
+
+Antes de sugerir, por favor veja se a mesma ideia já não foi sugerida antes (algumas vezes você verá que não precisa criar uma nova sugestão).
+
+#### Como submeter uma boa sugestão de melhoria?
+
+As melhorias tomam forma de [*Github Issues*](https://guides.github.com/features/issues/).
+
+- **Use um título claro e descritivo**;
+- **Providencie uma descrição detalhada da sugestão**;
+- **Explique o porquê desta melhoria ser útil**;
+- **Descreva um *antes e depois*, se aplicável**;
+- **Providencie exemplos, se aplicável**.
+
+### Criando *Pull Requests*
+
+Por favor siga os passos a seguir para que sua contribuição seja avaliada:
+
+1. Siga as instruções do modelo de *pull requests* ao criar um;
+2. Siga os [*guias de estilo*](#guias-de-estilo)
+
+Os pré-requisitos acima serem seguidos não significa que os mantenedores do projeto não possam pedir adições ao *pull request*, esclarecimento de informações, mudanças em alguns trechos, etc., antes da contribuição ser aceita.
+
+## Guias de estilo
+
+### Mensagens de *commit* do git
+
+- Use a segunda pessoa do Imperativo Afirmativo ("Adiciona guias de contribuição..." e não "Adicionando guias de contribuição...");
+- O título (primeira linha) deve conter 50 caracteres ou menos
+    - Escreva mensagem de *commit* objetiva sobre o que aquele commit muda no projeto.
+    - Tente responder "O que este *commit* faz?";
+- Caso haja descrição do *commit*, deixe a segunda linha em branco;
+- Adicione uma descrição do commit da terceira linha em diante, com 72 caracteres ou menos por linha;
+    - Ao se perguntar se é necessária uma descrição para o *commit*, se pergunte se alguém quiser investigar o "porquê desta mudança ter sido introduzida", será possível apenas pelo título e conteúdo do *commit*;
+    - Adicione uma descrição que responda a pergunta "Por que este *commit* é necessário?";
+- Rerefencie *issues* ou *pull requests* no fim da mensagem;
+
+Obrigado! :heart: :heart: :heart:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,6 @@ Os pré-requisitos acima serem seguidos não significa que os mantenedores do pr
 - Adicione uma descrição do commit da terceira linha em diante, com 72 caracteres ou menos por linha;
     - Ao se perguntar se é necessária uma descrição para o *commit*, se pergunte se alguém quiser investigar o "porquê desta mudança ter sido introduzida", será possível apenas pelo título e conteúdo do *commit*;
     - Adicione uma descrição que responda a pergunta "Por que este *commit* é necessário?";
-- Rerefencie *issues* ou *pull requests* no fim da mensagem;
+- Referencie *issues* ou *pull requests* no fim da mensagem;
 
 Obrigado! :heart: :heart: :heart:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
  5. [Organização no dia](arquivos/ORGANIZACAO-DIA.md)
 
 ## Contribuição
-  Esse repositório está aberto a contribuições, se você gostou de algo que foi realizado no PUG e gostaria de dar **feedbacks** ou **propor mudanças**, abra uma Issue ou faça um Pull Request.
 
-  Adoraríamos receber sua ajuda nessa jornada <3
+Este repositório está aberto a contribuições, se você gostou de algo que foi realizado no PUG e gostaria de dar **feedbacks** ou **propor mudanças**, leia nosso [guia de contribuição](CONTRIBUTING.md) e participe!
+
+Adoraríamos receber sua ajuda nessa jornada :heart:
 
 
 ## Código de Conduta


### PR DESCRIPTION
### Descrição da mudança

Adiciona um guia de contribuição para que todos que queiram contribuir com o repositório estejam na mesma página com relação ao que pode ser feito e como pode ser feito.

Inicialmente, só adicionei algumas padronizações, mas imagino que a gente poderia adicionar *template* de *issues*, guia de estilo de criação de arquivos, etc.