### PR TITLE
Corrige caminho de arquivos em inglês

### DIFF
--- a/files/english/README.md
+++ b/files/english/README.md
@@ -7,11 +7,11 @@
 >This repository serves as a guide for organizing and planning a [PUG-PE (Python User Group - Pernambuco)](http://pycon.pug.pe) meetup 
 
 ## Index
- 1. [Main Pipeline](files/english/PIPELINE.md)
- 2. [Set the date](files/english/SET-DATE.md)
- 3. [Create event on PUG-PE website](files/english/EVENTS-PUG.md)
- 4. [Promotion tips](files/english/PROMOTION.md)
- 5. [Organization on the day](files/english/ORGANIZATION-DAY.md)
+ 1. [Main Pipeline](PIPELINE.md)
+ 2. [Set the date](SET-DATE.md)
+ 3. [Create event on PUG-PE website](EVENTS-PUG.md)
+ 4. [Promotion tips](PROMOTION.md)
+ 5. [Organization on the day](ORGANIZATION-DAY.md)
 
 ## Contribution
   Contributions to this repository are welcome. If you liked something of any PUG meetup and would like to give **feedbacks** or **propose changes**, open an Issue or create a Pull Request.


### PR DESCRIPTION
### Descrição da mudança

O Caminhos dos arquivos no README-en.md estavam com o endereço errado. Para corrigir só alterei para o caminho relativo dos arquivos

<!--

Nós devemos conseguir entender o motivo da mudança através dessa descrição. Se não conseguirmos entender muito bem os benefícios que esta mudança trará, o *Pull Request* pode ser fechado.

-->
