### PR TITLE
Remove GitHub Stars shield

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,4 @@
 # Meetup Cookbook
-![GitHub stars](https://img.shields.io/github/stars/pugpe/meetup-cookbook?style=social)
 [![\[Telegram\] PUG-PE](https://img.shields.io/badge/telegram-pugpe-blue.svg?style=flat-square)](https://t.me/pugpe)
 ![Twitter Follow](https://img.shields.io/twitter/follow/pugpe?style=social)
 ![GitHub](https://img.shields.io/github/license/pugpe/meetup-cookbook)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Meetup Cookbook
-![GitHub stars](https://img.shields.io/github/stars/pugpe/meetup-cookbook?style=social)
 [![\[Telegram\] PUG-PE](https://img.shields.io/badge/telegram-pugpe-blue.svg?style=flat-square)](https://t.me/pugpe)
 ![Twitter Follow](https://img.shields.io/twitter/follow/pugpe?style=social)
 ![GitHub](https://img.shields.io/github/license/pugpe/meetup-cookbook)


### PR DESCRIPTION
### Descrição da mudança

Como a página do GitHub já oferece a informação das estrelas, acredito que não seja necessário o shield.